### PR TITLE
Use debug library (v2.1.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 *.js
 
 *.d.ts
-!/typings/*.d.ts
+!/typings/**/*.d.ts
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and it is available for purchase at
 
 ```js
 var i2cBus = require("i2c-bus");
-var Pca9685Driver = require("pca9685");
+var Pca9685Driver = require("pca9685").Pca9685Driver;
 
 var options = {
     i2c: i2cBus.openSync(1),

--- a/README.md
+++ b/README.md
@@ -51,11 +51,21 @@ driving LEDs without obvious flicker.
 during operations.
 
 
-## Note
+## Debugging
 
-This module is programmed in Typescript and includes typescript definitions
-for the module.
+This project uses the [`debug`](https://npmjs.org/package/debug) library for
+debugging.  This allows you to enable debugging using environment variables or in
+code before constructing the `Pca9685Driver` object.  The name of the debugging
+stream produced by the library is `pca9685`.See the debug library documentation
+for more information.
 
+
+## TypeScript
+
+This project is written in [TypeScript](http://www.typescriptlang.org/).  The
+library can be used by plain JavaScript as shown above, and the typing
+information is also included with the library so that anyone wishing to use
+Typescript will gain the benefits of the type information.
 
 ## Acknowledgements
 

--- a/examples/servo.ts
+++ b/examples/servo.ts
@@ -1,5 +1,15 @@
 /// <reference path="../typings/tsd.d.ts" />
 
+/*
+ * examples/servo.ts
+ * https://github.com/101100/pca9685
+ *
+ * Example to turn a servo motor in a loop.
+ *
+ * Copyright (c) 2015 Jason Heard
+ * Licensed under the MIT license.
+ */
+
 "use strict";
 
 import * as i2cBus from "i2c-bus";

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,13 @@
+/*
+ * index.ts
+ * https://github.com/101100/pca9685
+ *
+ * Library for PCA9685 I2C 16-channel PWM/servo driver.
+ *
+ * Copyright (c) 2015 Jason Heard
+ * Licensed under the MIT license.
+ */
+
 import { Pca9685Driver, Pca9685Options } from "./src/pca9685";
 
 export { Pca9685Driver as default, Pca9685Driver, Pca9685Options };

--- a/package.json
+++ b/package.json
@@ -42,5 +42,11 @@
   "devDependencies": {
     "i2c-bus": "^1.0",
     "typescript": "^1.7"
+  },
+  "dependencies": {
+    "debug": "^2.2"
+  },
+  "directories": {
+    "example": "examples"
   }
 }

--- a/src/pca9685.ts
+++ b/src/pca9685.ts
@@ -1,9 +1,15 @@
 /*jslint bitwise: true */
 /// <reference path = "../typings/tsd.d.ts" />
 
-// ============================================================================
-// PCA9685 I2C 16-channel PWM/servo driver
-// ============================================================================
+/*
+ * src/pca9685.ts
+ * https://github.com/101100/pca9685
+ *
+ * Library for PCA9685 I2C 16-channel PWM/servo driver.
+ *
+ * Copyright (c) 2015 Jason Heard
+ * Licensed under the MIT license.
+ */
 
 "use strict";
 

--- a/typings/debug/debug.d.ts
+++ b/typings/debug/debug.d.ts
@@ -1,0 +1,30 @@
+// Type definitions for debug
+// Project: https://github.com/visionmedia/debug
+// Definitions by: Seon-Wook Park <https://github.com/swook>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+declare module "debug" {
+
+    function d(namespace: string): d.Debugger;
+
+    module d {
+        export var log: Function;
+
+        function enable(namespaces: string): void;
+        function disable(): void;
+
+        function enabled(namespace: string): boolean;
+
+        export interface Debugger {
+            (formatter: any, ...args: any[]): void;
+
+            enabled:   boolean;
+            log:       Function;
+            namespace: string;
+        }
+    }
+
+    export = d;
+
+}
+

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -1,2 +1,3 @@
 /// <reference path = "./node-0.12.d.ts" />
+/// <reference path = "./debug/debug.d.ts" />
 /// <reference path = "./i2c-bus.d.ts" />


### PR DESCRIPTION
This changes the library to use the `debug` NPM library.  This allows enabling debugging with environment variables and in code at a global level.

After with is merged, this will be released as version 2.1.0.