### PR TITLE
PWM active on all channels

### DIFF
--- a/src/pca9685.ts
+++ b/src/pca9685.ts
@@ -28,6 +28,7 @@ const constants = {
     allChannelsOnStepHighByte: 0xFB, // ALL_LED_ON_H
     allChannelsOffStepLowByte: 0xFC, // ALL_LED_OFF_L
     allChannelsOffStepHighByte: 0xFD, // ALL_LED_OFF_H
+    turnOffChannel: 0x10, // must be sent to the off step high byte
     preScale: 0xFE, // PRE_SCALE
     stepsPerCycle: 4096,
     defaultAddress: 0x40,
@@ -197,8 +198,8 @@ export class Pca9685Driver {
      * Turns all channels off.
      */
     allChannelsOff(): void {
-        // Setting the high byte to 1 will turn off the channel
-        this.send(constants.allChannelsOffStepHighByte, 0x01);
+        // Setting the high byte to 0x10 will turn off all channels
+        this.send(constants.allChannelsOffStepHighByte, constants.turnOffChannel);
     }
 
 


### PR DESCRIPTION
Noob here with two issues

1. When testing the example scripts I noticed the PWM is active on all channels when it is first initialized.  In my instance, I had servos connected to channel 0 and channel 7. Both servos began to rotate after the new pwm instance was initialized.  I can turn them off using setPulseRange(channel, 0, 0) but I still get some movement at initialization. I don't have this issue when running the python sample scripts provided by adafruit. 

2. Maybe it's related to 1. but pwm.allChannelsOff() doesn't appear to do anything.  I assume the method turns off any active channel but when running the example scripts the servo remains active on the SIGINT process.on event. 

Hopefully it's just me not doing something right. Thanks for sharing your work!

******** Hardware: ***********
Raspberry pi 2
Adafruit 16 channel pwm / servo hat for rpi 
HS-311 servo
Parallax continuous rotation servo
-ctr 